### PR TITLE
feat: 1日1回の短歌作成制限を実装 (US-006)

### DIFF
--- a/Sources/Features/Feed/View/FeedView.swift
+++ b/Sources/Features/Feed/View/FeedView.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 struct FeedView: View {
     @Environment(\.tankaRepository) private var repository
+    @Environment(\.dailyLimitService) private var dailyLimitService
     @Binding var path: NavigationPath
     @State private var viewModel: FeedViewModel?
     @State private var showReportSheet = false
     @State private var showBlockAlert = false
+    @State private var hasCreatedToday = false
 
     var body: some View {
         content
@@ -16,7 +18,11 @@ struct FeedView: View {
                 if viewModel == nil {
                     viewModel = FeedViewModel(tankaRepository: repository)
                 }
+                hasCreatedToday = dailyLimitService.hasCreatedToday()
                 await viewModel?.loadFeed()
+            }
+            .onAppear {
+                hasCreatedToday = dailyLimitService.hasCreatedToday()
             }
             .refreshable {
                 await viewModel?.loadFeed()
@@ -99,8 +105,20 @@ struct FeedView: View {
             .padding(.vertical, 16)
         }
         .overlay(alignment: .bottomTrailing) {
-            FloatingActionButton {
-                path.append(FeedRoute.compose)
+            VStack(alignment: .trailing, spacing: 8) {
+                if hasCreatedToday {
+                    Text("明日また詠めます")
+                        .font(.appCaption())
+                        .foregroundStyle(Color.appSubText)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.appCardBackground, in: Capsule())
+                }
+                FloatingActionButton {
+                    path.append(FeedRoute.compose)
+                }
+                .opacity(hasCreatedToday ? 0.4 : 1)
+                .disabled(hasCreatedToday)
             }
             .padding(24)
         }

--- a/Sources/Features/Feed/View/TankaResultView.swift
+++ b/Sources/Features/Feed/View/TankaResultView.swift
@@ -6,6 +6,7 @@ struct TankaResultView: View {
     @Binding var path: NavigationPath
 
     @Environment(\.tankaRepository) private var repository
+    @Environment(\.dailyLimitService) private var dailyLimitService
     @State private var viewModel: TankaResultViewModel?
 
     var body: some View {
@@ -16,7 +17,10 @@ struct TankaResultView: View {
             .navigationBarBackButtonHidden(true)
             .task {
                 if viewModel == nil {
-                    viewModel = TankaResultViewModel(tankaRepository: repository)
+                    viewModel = TankaResultViewModel(
+                        tankaRepository: repository,
+                        dailyLimitService: dailyLimitService
+                    )
                 }
                 await viewModel?.generateTanka(category: category, worryText: worryText)
             }

--- a/Sources/Features/Feed/ViewModel/TankaResultViewModel.swift
+++ b/Sources/Features/Feed/ViewModel/TankaResultViewModel.swift
@@ -8,9 +8,14 @@ final class TankaResultViewModel {
     private(set) var error: AppError?
 
     private let tankaRepository: any TankaRepositoryProtocol
+    private let dailyLimitService: any DailyLimitServiceProtocol
 
-    init(tankaRepository: any TankaRepositoryProtocol) {
+    init(
+        tankaRepository: any TankaRepositoryProtocol,
+        dailyLimitService: any DailyLimitServiceProtocol
+    ) {
         self.tankaRepository = tankaRepository
+        self.dailyLimitService = dailyLimitService
     }
 
     func generateTanka(category: WorryCategory, worryText: String) async {
@@ -23,6 +28,7 @@ final class TankaResultViewModel {
                 worryText: worryText
             )
             generatedTanka = tanka
+            dailyLimitService.recordCreation()
         } catch {
             self.error = AppError(error)
         }

--- a/Sources/Shared/DI/DailyLimitService.swift
+++ b/Sources/Shared/DI/DailyLimitService.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+protocol DailyLimitServiceProtocol: Sendable {
+    func hasCreatedToday() -> Bool
+    func recordCreation()
+    func nextAvailableDate() -> Date?
+}
+
+final class DailyLimitService: DailyLimitServiceProtocol, @unchecked Sendable {
+    private let userDefaults: UserDefaults
+    private let key = "lastTankaCreationDate"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func hasCreatedToday() -> Bool {
+        guard let lastDate = userDefaults.object(forKey: key) as? Date else {
+            return false
+        }
+        return Calendar.current.isDateInToday(lastDate)
+    }
+
+    func recordCreation() {
+        userDefaults.set(Date(), forKey: key)
+    }
+
+    func nextAvailableDate() -> Date? {
+        guard hasCreatedToday() else { return nil }
+        return Calendar.current.startOfDay(for: Date()).addingTimeInterval(24 * 60 * 60)
+    }
+}
+
+#if DEBUG
+    final class PreviewDailyLimitService: DailyLimitServiceProtocol, @unchecked Sendable {
+        var stubbedHasCreatedToday = false
+
+        func hasCreatedToday() -> Bool {
+            stubbedHasCreatedToday
+        }
+
+        func recordCreation() {
+            stubbedHasCreatedToday = true
+        }
+
+        func nextAvailableDate() -> Date? {
+            guard stubbedHasCreatedToday else { return nil }
+            return Calendar.current.startOfDay(for: Date()).addingTimeInterval(24 * 60 * 60)
+        }
+    }
+#endif

--- a/Sources/Shared/DI/EnvironmentKeys.swift
+++ b/Sources/Shared/DI/EnvironmentKeys.swift
@@ -3,7 +3,9 @@ import SwiftUI
 extension EnvironmentValues {
     #if DEBUG
         @Entry var tankaRepository: any TankaRepositoryProtocol = PreviewTankaRepository()
+        @Entry var dailyLimitService: any DailyLimitServiceProtocol = PreviewDailyLimitService()
     #else
         @Entry var tankaRepository: any TankaRepositoryProtocol = TankaRepository()
+        @Entry var dailyLimitService: any DailyLimitServiceProtocol = DailyLimitService()
     #endif
 }

--- a/Tests/Features/Feed/TankaResultViewModelTests.swift
+++ b/Tests/Features/Feed/TankaResultViewModelTests.swift
@@ -6,9 +6,13 @@ struct TankaResultViewModelTests {
     @Test
     func generateTanka_success_setsGeneratedTanka() async {
         let mock = MockTankaRepository()
+        let dailyLimit = MockDailyLimitService()
         let expectedTanka = Tanka.mock()
         mock.stubbedGeneratedTanka = expectedTanka
-        let viewModel = TankaResultViewModel(tankaRepository: mock)
+        let viewModel = TankaResultViewModel(
+            tankaRepository: mock,
+            dailyLimitService: dailyLimit
+        )
 
         await viewModel.generateTanka(category: .work, worryText: "テスト悩み")
 
@@ -19,23 +23,48 @@ struct TankaResultViewModelTests {
     }
 
     @Test
+    func generateTanka_success_recordsCreation() async {
+        let mock = MockTankaRepository()
+        let dailyLimit = MockDailyLimitService()
+        mock.stubbedGeneratedTanka = Tanka.mock()
+        let viewModel = TankaResultViewModel(
+            tankaRepository: mock,
+            dailyLimitService: dailyLimit
+        )
+
+        await viewModel.generateTanka(category: .work, worryText: "テスト悩み")
+
+        #expect(dailyLimit.recordCreationCallCount == 1)
+        #expect(dailyLimit.stubbedHasCreatedToday == true)
+    }
+
+    @Test
     func generateTanka_failure_setsError() async {
         let mock = MockTankaRepository()
+        let dailyLimit = MockDailyLimitService()
         mock.stubbedError = NetworkError.serverError(statusCode: 500)
-        let viewModel = TankaResultViewModel(tankaRepository: mock)
+        let viewModel = TankaResultViewModel(
+            tankaRepository: mock,
+            dailyLimitService: dailyLimit
+        )
 
         await viewModel.generateTanka(category: .love, worryText: "テスト")
 
         #expect(viewModel.generatedTanka == nil)
         #expect(viewModel.error != nil)
         #expect(viewModel.isLoading == false)
+        #expect(dailyLimit.recordCreationCallCount == 0)
     }
 
     @Test
     func generateTanka_retry_clearsError() async {
         let mock = MockTankaRepository()
+        let dailyLimit = MockDailyLimitService()
         mock.stubbedError = NetworkError.noConnection
-        let viewModel = TankaResultViewModel(tankaRepository: mock)
+        let viewModel = TankaResultViewModel(
+            tankaRepository: mock,
+            dailyLimitService: dailyLimit
+        )
 
         await viewModel.generateTanka(category: .work, worryText: "テスト")
         #expect(viewModel.error != nil)

--- a/Tests/Mocks/MockDailyLimitService.swift
+++ b/Tests/Mocks/MockDailyLimitService.swift
@@ -1,0 +1,21 @@
+@testable import App
+import Foundation
+
+final class MockDailyLimitService: DailyLimitServiceProtocol, @unchecked Sendable {
+    var stubbedHasCreatedToday = false
+    var recordCreationCallCount = 0
+
+    func hasCreatedToday() -> Bool {
+        stubbedHasCreatedToday
+    }
+
+    func recordCreation() {
+        recordCreationCallCount += 1
+        stubbedHasCreatedToday = true
+    }
+
+    func nextAvailableDate() -> Date? {
+        guard stubbedHasCreatedToday else { return nil }
+        return Calendar.current.startOfDay(for: Date()).addingTimeInterval(24 * 60 * 60)
+    }
+}


### PR DESCRIPTION
## Summary
- `DailyLimitService` を追加し、UserDefaults で最終作成日を管理
- 短歌生成成功時に `recordCreation()` で作成日を記録
- FAB を制限到達時に無効化 + 「明日また詠めます」メッセージを表示
- `DailyLimitServiceProtocol` で DI し、テスト・プレビューで差し替え可能

## Test plan
- [x] 全49テスト合格
- [ ] シミュレータで短歌生成後、FAB が無効化されることを確認
- [ ] 日付が変わった後、FAB が有効に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)