### PR TITLE
feat(share): 短歌カードの画像シェア機能 (US-012)

### DIFF
--- a/Sources/Features/Feed/View/TankaResultView.swift
+++ b/Sources/Features/Feed/View/TankaResultView.swift
@@ -55,6 +55,8 @@ struct TankaResultView: View {
                 .font(.appCaption())
                 .foregroundStyle(Color.appSubText)
 
+            ShareButton(tanka: tanka)
+
             Spacer()
 
             Button {

--- a/Sources/Shared/Components/ShareButton.swift
+++ b/Sources/Shared/Components/ShareButton.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct ShareButton: View {
+    let tanka: Tanka
+
+    @State private var shareImage: UIImage?
+    @State private var isShowingShareSheet = false
+
+    var body: some View {
+        Button {
+            generateAndShare()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "square.and.arrow.up")
+                Text("シェア")
+            }
+            .font(.appCaption())
+            .foregroundStyle(Color.appSubText)
+        }
+        .sheet(isPresented: $isShowingShareSheet) {
+            if let shareImage {
+                ShareSheet(items: [shareImage])
+            }
+        }
+    }
+
+    @MainActor
+    private func generateAndShare() {
+        let renderer = ImageRenderer(content: TankaShareImage(tanka: tanka))
+        renderer.scale = 1.0
+        if let image = renderer.uiImage {
+            shareImage = image
+            isShowingShareSheet = true
+        }
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIActivityViewController,
+        context: Context
+    ) {}
+}

--- a/Sources/Shared/Components/TankaCard.swift
+++ b/Sources/Shared/Components/TankaCard.swift
@@ -81,6 +81,10 @@ struct TankaCard: View {
             Spacer()
             VerticalText(text: tanka.tankaText)
             Spacer()
+            HStack {
+                Spacer()
+                ShareButton(tanka: tanka)
+            }
         }
         .frame(maxWidth: .infinity, minHeight: 200)
         .padding(24)

--- a/Sources/Shared/Components/TankaShareImage.swift
+++ b/Sources/Shared/Components/TankaShareImage.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct TankaShareImage: View {
+    let tanka: Tanka
+
+    var body: some View {
+        ZStack {
+            // 和紙風の暖かいグラデーション背景
+            LinearGradient(
+                colors: [
+                    Color(red: 0.96, green: 0.94, blue: 0.90),
+                    Color(red: 0.98, green: 0.96, blue: 0.93)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            VStack(spacing: 0) {
+                // カテゴリラベル（上部）
+                Text(tanka.category.displayName)
+                    .font(.system(size: 28, weight: .light))
+                    .foregroundStyle(Color(red: 0.5, green: 0.48, blue: 0.45))
+                    .padding(.top, 80)
+
+                Spacer()
+
+                // 縦書き短歌テキスト（中央）
+                VerticalText(
+                    text: tanka.tankaText,
+                    fontSize: 48
+                )
+
+                Spacer()
+
+                // ウォーターマーク（右下）
+                HStack {
+                    Spacer()
+                    Text("こころうた")
+                        .font(.system(size: 24, weight: .light))
+                        .foregroundStyle(Color(red: 0.7, green: 0.68, blue: 0.65))
+                }
+                .padding(.bottom, 60)
+                .padding(.trailing, 60)
+            }
+        }
+        .frame(width: 1080, height: 1080)
+    }
+}


### PR DESCRIPTION
## Summary
- 短歌カードを画像として生成し、iOS シェアシートで共有する機能を実装
- `ImageRenderer` (iOS 16+) で SwiftUI View → UIImage 変換
- 和紙風背景 + 縦書き短歌 + 「こころうた」ウォーターマークの1080x1080シェア画像

## 新規ファイル
- **TankaShareImage.swift**: シェア用の短歌画像View（1080x1080、和紙風グラデーション背景、縦書き短歌、ウォーターマーク）
- **ShareButton.swift**: シェアボタン + ShareSheet（UIActivityViewController ラッパー）

## 変更ファイル
- **TankaCard.swift**: 裏面（短歌表示面）にシェアボタン追加
- **TankaResultView.swift**: 結果画面にシェアボタン追加

## Test plan
- [ ] TankaCard の裏面にシェアボタンが表示されること
- [ ] TankaResultView にシェアボタンが表示されること
- [ ] シェアボタンタップで画像が生成されシェアシートが表示されること
- [ ] シェア画像が1080x1080の正方形であること
- [ ] SwiftLint / SwiftFormat 違反がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)