### PR TITLE
refactor(auth): エミュレーター接続を環境変数で切り替え

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -9,9 +9,9 @@ struct MainApp: SwiftUI.App {
     init() {
         FirebaseApp.configure()
 
-        #if DEBUG
+        if ProcessInfo.processInfo.environment["USE_EMULATOR"] == "1" {
             Auth.auth().useEmulator(withHost: "localhost", port: 9099)
-        #endif
+        }
     }
 
     var body: some Scene {

--- a/Sources/Shared/Networking/APIClient.swift
+++ b/Sources/Shared/Networking/APIClient.swift
@@ -11,9 +11,9 @@ final class APIClient: Sendable {
     init(functions: Functions = Functions.functions(region: "asia-northeast1")) {
         self.functions = functions
 
-        #if DEBUG
+        if ProcessInfo.processInfo.environment["USE_EMULATOR"] == "1" {
             self.functions.useEmulator(withHost: "localhost", port: 5001)
-        #endif
+        }
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601


### PR DESCRIPTION
## Summary
- Firebase Emulator 接続を `#if DEBUG` 固定から環境変数 `USE_EMULATOR` による切り替えに変更
- デフォルトは本番 Firebase に接続（エミュレーター起動不要で開発可能）
- エミュレーター使用時は Xcode スキームで `USE_EMULATOR=1` を設定

## 変更ファイル
- **App.swift**: `Auth.auth().useEmulator()` を `ProcessInfo.environment["USE_EMULATOR"]` で条件分岐
- **APIClient.swift**: `Functions.useEmulator()` を同様に条件分岐

## Test plan
- [ ] `USE_EMULATOR` 未設定で本番 Firebase に接続できること
- [ ] `USE_EMULATOR=1` 設定でエミュレーターに接続できること
- [ ] 既存テスト 48件が全てパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)