### PR TITLE
fix(ci): Firebase import に @preconcurrency を追加して Sendable エラーを解消

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -1,6 +1,6 @@
-import FirebaseAuth
+@preconcurrency import FirebaseAuth
 import FirebaseCore
-import FirebaseFirestore
+@preconcurrency import FirebaseFirestore
 import SwiftUI
 
 @main

--- a/Sources/Shared/Networking/APIClient.swift
+++ b/Sources/Shared/Networking/APIClient.swift
@@ -1,5 +1,5 @@
-import FirebaseAuth
-import FirebaseFunctions
+@preconcurrency import FirebaseAuth
+@preconcurrency import FirebaseFunctions
 import Foundation
 
 final class APIClient: Sendable {


### PR DESCRIPTION
## 概要
Firebase SDK の型が `Sendable` に準拠していないため、Swift 6.2 の厳格な並行性チェックで CI ビルドが失敗していた問題を修正。

## 変更内容
- `Sources/App/App.swift`: `FirebaseAuth` / `FirebaseFirestore` の import に `@preconcurrency` を追加
- `Sources/Shared/Networking/APIClient.swift`: `FirebaseAuth` / `FirebaseFunctions` の import に `@preconcurrency` を追加

## 対応方針
Firebase SDK が正式に `Sendable` に対応するまでの暫定措置として `@preconcurrency import` を使用し、Sendable 関連の警告・エラーを抑制する。

Closes #20