### PR TITLE
feat(model): 悩みカテゴリに「その他」を追加

### DIFF
--- a/Sources/Features/Feed/View/ComposeView.swift
+++ b/Sources/Features/Feed/View/ComposeView.swift
@@ -38,13 +38,15 @@ struct ComposeView: View {
                 .font(.appCaption())
                 .foregroundStyle(Color.appSubText)
 
-            HStack(spacing: 8) {
-                ForEach(WorryCategory.allCases, id: \.self) { category in
-                    CategoryChip(
-                        category: category,
-                        isSelected: viewModel.selectedCategory == category
-                    ) {
-                        viewModel.selectCategory(category)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(WorryCategory.allCases, id: \.self) { category in
+                        CategoryChip(
+                            category: category,
+                            isSelected: viewModel.selectedCategory == category
+                        ) {
+                            viewModel.selectCategory(category)
+                        }
                     }
                 }
             }

--- a/Sources/Shared/Model/WorryCategory.swift
+++ b/Sources/Shared/Model/WorryCategory.swift
@@ -5,6 +5,7 @@ enum WorryCategory: String, Codable, Sendable, CaseIterable {
     case love
     case work
     case health
+    case other
 
     var displayName: String {
         switch self {
@@ -12,6 +13,7 @@ enum WorryCategory: String, Codable, Sendable, CaseIterable {
         case .love: "恋愛"
         case .work: "仕事"
         case .health: "健康"
+        case .other: "その他"
         }
     }
 }

--- a/functions/src/generateTanka.ts
+++ b/functions/src/generateTanka.ts
@@ -5,7 +5,7 @@ import OpenAI from "openai";
 
 const openaiApiKey = defineSecret("OPENAI_API_KEY");
 
-const VALID_CATEGORIES = ["relationship", "love", "work", "health"];
+const VALID_CATEGORIES = ["relationship", "love", "work", "health", "other"];
 
 export const generateTanka = onCall(
   {
@@ -56,6 +56,7 @@ export const generateTanka = onCall(
       love: "恋愛",
       work: "仕事",
       health: "健康",
+      other: "その他",
     };
 
     const completion = await openai.chat.completions.create({


### PR DESCRIPTION
## 概要
- 悩みカテゴリに「その他」を追加し、既存4カテゴリに当てはまらない悩みにも対応
- サーバー側の `VALID_CATEGORIES` と `categoryLabel` も同期

## 変更内容
- `WorryCategory` enum に `other` ケースを追加（displayName: "その他"）
- `generateTanka.ts` の `VALID_CATEGORIES` に `"other"` を追加
- `generateTanka.ts` の `categoryLabel` に `other: "その他"` を追加
- `ComposeView` のカテゴリセクションを横スクロール対応（5カテゴリで溢れ防止）

## テスト結果
- 全48テストがパス
- ビルド成功

## 注意事項
- Cloud Functions の再デプロイが必要です

Closes #17