### PR TITLE
improvement(server): lastTankaDate を Timestamp 型に変更し dailyTankaCount を追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -513,7 +513,8 @@ firestore/
 ├── users/                          # ユーザーコレクション
 │   └── {userID}/
 │       ├── createdAt: timestamp
-│       ├── lastTankaDate: string   # "YYYY-MM-DD" 形式（1日1回制限用）
+│       ├── lastTankaCreatedAt: timestamp  # 最後の短歌生成日時（日次制限用）
+│       ├── dailyTankaCount: number        # 当日の短歌生成回数
 │       └── blockedUsers/           # サブコレクション
 │           └── {blockedUserID}/
 │               └── createdAt: timestamp

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,7 +17,7 @@
 | マイ短歌 | My Tanka | ユーザー自身が過去に生成した短歌の一覧 | `MyTankaView`, `MyTankaViewModel` |
 | 通報 | Report | 不適切なコンテンツを運営に報告する機能 | `Report`, `ReportSheet`, `ReportReason` |
 | ブロック | Block | 特定ユーザーの短歌をフィードから非表示にする機能 | `BlockedUser`, `BlockListView` |
-| 1日1回制限 | Daily Limit | 1日に1つだけ短歌を生成できる制限 | `lastTankaDate`, `canCompose` |
+| 日次制限 | Daily Limit | 1日に生成可能な短歌数の制限（`MAX_DAILY_TANKA` で管理） | `lastTankaCreatedAt`, `dailyTankaCount`, `canCompose` |
 
 ## 2. 技術用語
 


### PR DESCRIPTION
## 概要

`users` コレクションの `lastTankaDate` (String) を `lastTankaCreatedAt` (Firestore Timestamp) に移行し、`dailyTankaCount` フィールドを追加して将来の1日N回制限に対応可能な構造にする。

## 変更内容

### サーバー側 (`functions/src/generateTanka.ts`)
- `MAX_DAILY_TANKA` 定数を追加（現在値: 1）
- レートリミット判定を `lastTankaCreatedAt` (Timestamp) + `dailyTankaCount` ベースに変更
- 既存の `lastTankaDate` (string) データとの後方互換性を維持（フォールバック処理）
- ユーザードキュメント更新時に `lastTankaCreatedAt` と `dailyTankaCount` を書き込み

### ドキュメント
- `docs/architecture.md`: Firestore スキーマ定義を更新
- `docs/glossary.md`: 日次制限の用語定義を更新

### iOS クライアント
- 変更なし（エラーコード `resource-exhausted` は変更されないため）

## 将来の拡張
- `MAX_DAILY_TANKA` の値を変更するだけで1日N回制限に切り替え可能
- Remote Config への移行も容易

Closes #31