### PR TITLE
feat(ui): 短歌生成結果を TankaCard で表示する

### DIFF
--- a/Sources/Features/Feed/View/ComposeView.swift
+++ b/Sources/Features/Feed/View/ComposeView.swift
@@ -62,10 +62,10 @@ struct ComposeView: View {
         case .loading:
             LoadingView(message: "短歌を詠んでいます...")
                 .transition(.opacity)
-        case .result(let tanka):
+        case let .result(tanka):
             resultContent(tanka: tanka)
                 .transition(.opacity)
-        case .error(let error):
+        case let .error(error):
             errorContent(error: error, viewModel: viewModel)
                 .transition(.opacity)
         }

--- a/Sources/Features/Feed/ViewModel/ComposeViewModel.swift
+++ b/Sources/Features/Feed/ViewModel/ComposeViewModel.swift
@@ -65,8 +65,10 @@ final class ComposeViewModel {
     }
 
     var isRateLimited: Bool {
-        if case .error(let error) = phase,
-           case .rateLimited = error {
+        if
+            case let .error(error) = phase,
+            case .rateLimited = error
+        {
             return true
         }
         return false

--- a/Sources/Shared/Components/TankaCard.swift
+++ b/Sources/Shared/Components/TankaCard.swift
@@ -98,7 +98,7 @@ struct TankaCard: View {
     private var backFace: some View {
         VStack {
             Spacer()
-            if useAnimatedBackFace && !hasAnimatedOnce {
+            if useAnimatedBackFace, !hasAnimatedOnce {
                 AnimatedVerticalText(text: tanka.tankaText)
             } else {
                 VerticalText(text: tanka.tankaText)

--- a/Tests/Features/Feed/TankaResultViewModelTests.swift
+++ b/Tests/Features/Feed/TankaResultViewModelTests.swift
@@ -79,8 +79,10 @@ struct ComposeSubmitTests {
         await viewModel.submitTanka()
 
         #expect(viewModel.generatedTanka == nil)
-        if case .error(let error) = viewModel.phase,
-           case let .validation(message) = error {
+        if
+            case let .error(error) = viewModel.phase,
+            case let .validation(message) = error
+        {
             #expect(message == "もう少し詳しく悩みを書いてください。")
         } else {
             Issue.record("Expected .validation error but got \(viewModel.phase)")


### PR DESCRIPTION
## 概要

- 生成結果画面の `AnimatedVerticalText` を `TankaCard` コンポーネントに置き換え
- フィード画面と一貫した見た目・操作感を提供
- カードタップでフリップして悩みテキスト / 短歌テキストを切り替え可能に

## 変更内容

### TankaCard.swift
- `initialFlipped: Bool` パラメータ追加（裏面から表示開始可能に）
- `useAnimatedBackFace: Bool` パラメータ追加（初回のみ `AnimatedVerticalText` を使用）
- `hasAnimatedOnce` 状態で初回アニメーション後は `VerticalText` にフォールバック
- Result Card 用の Preview を追加

### ComposeView.swift
- `resultContent` で `AnimatedVerticalText` + `ShareButton` → `TankaCard(initialFlipped: true, useAnimatedBackFace: true)` に置き換え
- シェアボタンは `TankaCard` 裏面に統合済み

## テスト計画
- [ ] 生成結果画面で TankaCard が表示されることを確認
- [ ] カードタップでフリップして悩みテキストが表示されることを確認
- [ ] 初回表示時に句ごとフェードインアニメーションが再生されることを確認
- [ ] フリップ後に戻した際は通常の VerticalText で表示されることを確認
- [ ] フィード画面の TankaCard が従来通り動作することを確認（リグレッションなし）

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)