### PR TITLE
build(config): 本番ビルド環境のセットアップ (#46)

### DIFF
--- a/Sources/App/Info.plist
+++ b/Sources/App/Info.plist
@@ -23,5 +23,7 @@
     </dict>
     <key>UILaunchScreen</key>
     <dict/>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>短歌の画像を保存するために写真ライブラリへのアクセスが必要です</string>
 </dict>
 </plist>

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,7 +1,13 @@
 # App ID and Apple ID configuration
-# Replace with your actual values
-app_identifier("com.example.yourapp") # The bundle identifier of your app
-apple_id("your@email.com") # Your Apple Developer email
+#
+# 環境変数で設定する（.env.default や CI シークレットを利用）:
+#   APP_IDENTIFIER  — アプリの Bundle Identifier
+#   APPLE_ID        — Apple Developer アカウントのメールアドレス
+#   TEAM_ID         — Apple Developer Team ID
+#
+app_identifier(ENV["APP_IDENTIFIER"] || "com.example.kokorouta")
+apple_id(ENV["APPLE_ID"] || "your@email.com")
+team_id(ENV["TEAM_ID"] || "YOUR_TEAM_ID")
 
 # For more information about the Appfile, see:
 # https://docs.fastlane.tools/advanced/#appfile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,13 +33,30 @@ platform :ios do
   # ============================================================
   desc "Build and upload to TestFlight"
   lane :beta do
-    increment_build_number
+    begin
+      increment_build_number
+      build_app(
+        scheme: ENV["SCHEME"] || "App",
+        export_method: "app-store"
+      )
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true
+      )
+    rescue => e
+      UI.error("Beta lane failed: #{e.message}")
+      raise e
+    end
+  end
+
+  # ============================================================
+  # Gym (Build only)
+  # ============================================================
+  desc "Build the app for distribution (without uploading)"
+  lane :gym_build do
     build_app(
       scheme: ENV["SCHEME"] || "App",
-      export_method: "app-store"
-    )
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true
+      export_method: "app-store",
+      skip_upload: true
     )
   end
 end

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,12 @@ settings:
   base:
     SWIFT_VERSION: "6.2"
     SWIFT_STRICT_CONCURRENCY: complete
+    # コード署名設定
+    # DEVELOPMENT_TEAM は環境変数から取得する。
+    # ローカルビルド: export DEVELOPMENT_TEAM="YOUR_TEAM_ID"
+    # CI: シークレットとして設定する
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: $(DEVELOPMENT_TEAM)
 
 packages:
   Firebase:


### PR DESCRIPTION
## Summary

- `project.yml` にコード署名設定（`CODE_SIGN_STYLE: Automatic`, `DEVELOPMENT_TEAM`）を追加。環境変数 `$(DEVELOPMENT_TEAM)` で参照するためシークレットがリポジトリにコミットされない
- `fastlane/Appfile` を環境変数ベースに変更（`APP_IDENTIFIER`, `APPLE_ID`, `TEAM_ID`）し、フォールバック値付きで安全にデフォルト動作する構成に
- `fastlane/Fastfile` の `beta` lane に `begin/rescue` によるエラーハンドリングを追加。アップロードなしでビルドのみ実行する `gym_build` lane を新設
- `Sources/App/Info.plist` に `NSPhotoLibraryAddUsageDescription` を追加（短歌画像の保存機能で必要）

## Test plan

- [ ] `xcodegen generate` でプロジェクトが正常に生成されることを確認
- [ ] `DEVELOPMENT_TEAM` 環境変数を設定した状態で Xcode のコード署名が Automatic になっていることを確認
- [ ] `bundle exec fastlane build` がシミュレータ向けに正常動作することを確認
- [ ] `bundle exec fastlane gym_build` が実行できることを確認（署名が必要）
- [ ] Info.plist に写真ライブラリ使用説明が表示されることを確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)