### PR TITLE
fix(settings): アカウント削除画面の白画面表示を修正

### DIFF
--- a/Sources/Features/Settings/View/AccountDeleteView.swift
+++ b/Sources/Features/Settings/View/AccountDeleteView.swift
@@ -24,6 +24,8 @@ struct AccountDeleteView: View {
             } else {
                 deleteFormContent(viewModel: viewModel)
             }
+        } else {
+            LoadingView()
         }
     }
 


### PR DESCRIPTION
## Summary
- AccountDeleteView で `viewModel` が `nil` の間 `EmptyView` が返り白画面が表示されていた問題を修正
- `else` ブランチで `LoadingView()` を表示するように変更

## Test plan
- [ ] 設定画面からアカウント削除ボタンをタップし、白画面ではなくローディング→削除フォームが表示されることを確認
- [ ] ViewModel の読み込み完了後、削除フォームが正しく表示されることを確認

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)