### PR TITLE
fix(feed): アプリ再起動時に短歌作成ボタンの状態を正しく反映

### DIFF
--- a/Sources/Features/Feed/View/FeedNavigationView.swift
+++ b/Sources/Features/Feed/View/FeedNavigationView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct FeedNavigationView: View {
+    @Environment(\.tankaRepository) private var repository
     @State private var path = NavigationPath()
     @State private var hasReachedDailyLimit = false
 
@@ -16,6 +17,24 @@ struct FeedNavigationView: View {
                         )
                     }
                 }
+        }
+        .task {
+            await checkDailyLimit()
+        }
+    }
+
+    private func checkDailyLimit() async {
+        do {
+            let myTankaList = try await repository.fetchMyTanka()
+            let calendar = Calendar.current
+            let hasCreatedToday = myTankaList.contains { tanka in
+                calendar.isDateInToday(tanka.createdAt)
+            }
+            if hasCreatedToday {
+                hasReachedDailyLimit = true
+            }
+        } catch {
+            // 取得に失敗した場合はボタンを有効のままにする（サーバー側でも制限される）
         }
     }
 }


### PR DESCRIPTION
## Summary
- `@State` の `hasReachedDailyLimit` がアプリ再起動で `false` にリセットされ、作成済みでもボタンが押せてしまう問題を修正
- `.task` 修飾子で `fetchMyTanka()` を呼び出し、当日の作成済み短歌を確認してボタン状態を正しく設定

## Test plan
- [ ] 短歌を作成した後、アプリを再起動してもボタンが非アクティブ状態になっていることを確認
- [ ] まだ作成していない日にはボタンがアクティブであることを確認
- [ ] API 取得失敗時にはボタンがアクティブのままであることを確認（サーバー側のフォールバック）

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)