### PR TITLE
fix(config): ホーム画面のアプリ表示名を「こころうた」に設定

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,7 @@ targets:
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "1"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        INFOPLIST_KEY_CFBundleDisplayName: こころうた
     dependencies:
       - package: Firebase
         product: FirebaseAuth


### PR DESCRIPTION
## Summary
- `project.yml` に `INFOPLIST_KEY_CFBundleDisplayName: こころうた` を追加
- ホーム画面でアプリ名が「App」ではなく「こころうた」と表示されるように修正

## Test plan
- [ ] シミュレータまたは実機にインストールし、ホーム画面でアプリ名が「こころうた」と表示されることを確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)